### PR TITLE
macOS: fix name too large error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = backlooper
-version = 0.2.0
+version = 0.2.1
 author = Steven van Gemert
 author_email = steven@vangemert.dev
 description = Backlooper.app is a looper that allows you to decide to loop a few bars after you played them

--- a/src/backlooper/audio.py
+++ b/src/backlooper/audio.py
@@ -29,7 +29,7 @@ _DEFAULT_BPM_VALUE = float('nan')
 _SHARED_FLOAT_TYPE = 'd'
 _SHARED_INT_TYPE = 'i'
 _LOOPER_FIELDS_PER_TRACK = 3
-_IDENTIFIER_LENGTH = 7  # since KeyOffset name can be max. 14 on BSD, use 7 for the identifier
+_IDENTIFIER_LENGTH = 7  # since KeyOffset name can be max. 14 on macOS, use 7 for the identifier
 
 logger = logging.getLogger(__name__)
 

--- a/src/backlooper/audio.py
+++ b/src/backlooper/audio.py
@@ -6,6 +6,7 @@ Information is shared by ``multiprocessing``.
 The audio interface is controlled by ``sounddevice``.
 """
 
+import hashlib
 import logging
 import time
 import webbrowser
@@ -28,6 +29,7 @@ _DEFAULT_BPM_VALUE = float('nan')
 _SHARED_FLOAT_TYPE = 'd'
 _SHARED_INT_TYPE = 'i'
 _LOOPER_FIELDS_PER_TRACK = 3
+_IDENTIFIER_LENGTH = 7  # since KeyOffset name can be max. 14 on BSD, use 7 for the identifier
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +59,8 @@ class AudioStream:
         self._clicktrack_bpm = Value(_SHARED_FLOAT_TYPE, _DEFAULT_BPM_VALUE)
         self._clicktrack_origin = Value(_SHARED_FLOAT_TYPE, _DEFAULT_ORIGIN_VALUE)
 
-        self._storage_identifier = uuid4()
-        self._storage = StripedStorage(identifier=str(self._storage_identifier))
+        self._storage_identifier = hashlib.sha256(str(uuid4()).encode()).hexdigest()[:_IDENTIFIER_LENGTH]
+        self._storage = StripedStorage(identifier=self._storage_identifier)
         self._time_between_blocks = self.block_size / self.sample_rate
         self._current_index = 0  # time when _samples_origin is initialized, has _current_index 0
         self._samples_origin = Value(_SHARED_FLOAT_TYPE, _DEFAULT_ORIGIN_VALUE)

--- a/src/backlooper/striped_storage.py
+++ b/src/backlooper/striped_storage.py
@@ -54,7 +54,6 @@ class StripedStorage:
     def __post_init__(self):
         self._stripe_size_bytes = self._empty_storage().nbytes
         self._memory_handles = {}  # TODO: garbage collecting
-        self._unique_prefix = self.identifier + '-'
 
     def _empty_storage(self):
         """Returns a stripe without any data."""
@@ -66,11 +65,11 @@ class StripedStorage:
         requested data.
         ``start_index`` can be bigger than the stripe size.
         """
-        return self._unique_prefix + str(floor(start_index / self.stripe_size)), start_index % self.stripe_size
+        return self.identifier + str(floor(start_index / self.stripe_size)), start_index % self.stripe_size
 
     def _key_offset_to_index(self, key: KeyOffset) -> int:
         """Inverse of ``_index_to_key_offset``."""
-        return int(key[0][len(self._unique_prefix):]) * self.stripe_size + key[1]
+        return int(key[0][len(self.identifier):]) * self.stripe_size + key[1]
 
     def read(
             self,

--- a/src/backlooper/tests/test_striped_storage.py
+++ b/src/backlooper/tests/test_striped_storage.py
@@ -25,22 +25,22 @@ class TestStripedStorage(TestCase):
             array_to_store=audio
         )
         desired_storage = {
-            prefix + '-33': np.array([
+            prefix + '33': np.array([
                 [0., 1.],
                 [2., 3.],
                 [4., 5.]
             ]),
-            prefix + '-34': np.array([
+            prefix + '34': np.array([
                 [6., 7.],
                 [8., 9.],
                 [10., 11.]
             ]),
-            prefix + '-35': np.array([
+            prefix + '35': np.array([
                 [12., 13.],
                 [14., 15.],
                 [16., 17.]
             ]),
-            prefix + '-36': np.array([
+            prefix + '36': np.array([
                 [18., 19.],
                 [20., 21.],
                 [0., 0.]
@@ -78,22 +78,22 @@ class TestStripedStorage(TestCase):
             overwrite=False,
         )
         desired_storage = {
-            prefix + '-33': 2*np.array([
+            prefix + '33': 2*np.array([
                 [0., 1.],
                 [2., 3.],
                 [4., 5.]
             ]),
-            prefix + '-34': 2*np.array([
+            prefix + '34': 2*np.array([
                 [6., 7.],
                 [8., 9.],
                 [10., 11.]
             ]),
-            prefix + '-35': 2*np.array([
+            prefix + '35': 2*np.array([
                 [12., 13.],
                 [14., 15.],
                 [16., 17.]
             ]),
-            prefix + '-36': 2*np.array([
+            prefix + '36': 2*np.array([
                 [18., 19.],
                 [20., 21.],
                 [0., 0.]
@@ -125,17 +125,17 @@ class TestStripedStorage(TestCase):
             array_to_store=audio
         )
         desired_storage = {
-            prefix + '-33': np.array([
+            prefix + '33': np.array([
                 [0., 0.],
                 [0., 0.],
                 [0., 1.]
             ]),
-            prefix + '-34': np.array([
+            prefix + '34': np.array([
                 [2., 3.],
                 [4., 5.],
                 [6., 7.]
             ]),
-            prefix + '-35': np.array([
+            prefix + '35': np.array([
                 [8., 9.],
                 [10., 11.],
                 [12., 13.]
@@ -166,7 +166,7 @@ class TestStripedStorage(TestCase):
             array_to_store=audio
         )
         desired_storage = {
-            prefix + '-33': np.array([
+            prefix + '33': np.array([
                 [0., 0.],
                 [1., 2.],
                 [0., 0.]
@@ -247,7 +247,7 @@ class TestStripedStorage(TestCase):
         prefix = str(uuid4())
         storage = StripedStorage(identifier=prefix, stripe_size=100)
         self.assertEqual(
-            (prefix+'-11', 50),
+            (prefix+'11', 50),
             storage._index_to_key_offset(1150)
         )
 
@@ -256,5 +256,5 @@ class TestStripedStorage(TestCase):
         storage = StripedStorage(identifier=prefix, stripe_size=100)
         self.assertEqual(
             1150,
-            storage._key_offset_to_index((prefix+'-11', 50))
+            storage._key_offset_to_index((prefix+'11', 50))
         )


### PR DESCRIPTION
https://github.com/spmvg/backlooper_backend/issues/2

## Testing
* Checked that the key prefix of the KeyOffset is now length 7 -> OK
* Unit tests pass
* End to end test: looping a track still works (but not tested on macOS since I don't have one)